### PR TITLE
Remove RPC microservice usage

### DIFF
--- a/controller/comment.go
+++ b/controller/comment.go
@@ -1,16 +1,13 @@
 package controller
 
 import (
-	"context"
 	"encoding/json"
 	"github.com/RaymondCode/simple-demo/model"
 	"github.com/RaymondCode/simple-demo/model/request"
 	"github.com/RaymondCode/simple-demo/model/response"
-	"github.com/RaymondCode/simple-demo/pb/rpcComment"
+	"github.com/RaymondCode/simple-demo/service"
 	"github.com/RaymondCode/simple-demo/utils/verify"
 	"github.com/gin-gonic/gin"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"log"
 	"net/http"
 )
@@ -40,32 +37,21 @@ func CommentAction(c *gin.Context) {
 		return
 	}
 
-	// rpc client
-	conn, err := grpc.Dial("localhost:50054", grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		log.Fatalf("did not connect: %v", err)
+	cs := service.CommentService{}
+	var comment *model.Comment
+	if commentRequest.ActionType == "1" {
+		comment, err = cs.CommentAction(userInfoVar.ID, &commentRequest)
+	} else if commentRequest.ActionType == "2" {
+		err = cs.DeleteCommentAction(&commentRequest)
 	}
-	defer conn.Close()
-	client := rpcComment.NewRPCCommentServiceClient(conn)
-
-	// call server
-	resp, err := client.Comment(context.Background(), &rpcComment.CommentRequest{
-		Token:       commentRequest.Token,
-		VideoId:     commentRequest.VideoID,
-		ActionType:  commentRequest.ActionType,
-		CommentText: commentRequest.CommentText,
-		CommentId:   commentRequest.CommentID,
-		UserId:      userInfoVar.ID,
-	})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, Response{StatusCode: 1, StatusMsg: "error in commentAction: " + err.Error()})
+		return
 	}
 	c.JSON(http.StatusOK, response.CommentActionResponse{
 		Response: response.Response{StatusCode: 0},
-		Comment:  resp.Comment,
+		Comment:  comment,
 	})
-
-	// call service: action_type = 1 add comment; action_type = 2 delete comment
 
 }
 
@@ -88,28 +74,15 @@ func CommentList(c *gin.Context) {
 		return
 	}
 
-	// rpc client
-	conn, err := grpc.Dial("localhost:50054", grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		log.Fatalf("did not connect: %v", err)
-	}
-	defer conn.Close()
-	client := rpcComment.NewRPCCommentServiceClient(conn)
-
-	// call server
-	resp, err := client.GetCommentList(context.Background(), &rpcComment.CommentListReq{
-		Token:   commentListRequest.Token,
-		VideoId: commentListRequest.VideoID,
-		UserId:  userInfoVar.ID,
-	})
+	cs := service.CommentService{}
+	commentList, err := cs.CommentList(userInfoVar.ID, &commentListRequest)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, Response{StatusCode: 1, StatusMsg: "error in commentList: " + err.Error()})
 		return
 	}
 
-	// return
 	c.JSON(http.StatusOK, response.CommentListResponse{
 		Response:    response.Response{StatusCode: 0},
-		CommentList: resp.CommentList,
+		CommentList: commentList,
 	})
 }

--- a/controller/favorite.go
+++ b/controller/favorite.go
@@ -1,17 +1,14 @@
 package controller
 
 import (
-	"context"
 	"encoding/json"
 	"github.com/RaymondCode/simple-demo/model"
 	"github.com/RaymondCode/simple-demo/model/request"
 	"github.com/RaymondCode/simple-demo/model/response"
-	"github.com/RaymondCode/simple-demo/pb/rpcFavorite"
+	"github.com/RaymondCode/simple-demo/service"
 	"github.com/RaymondCode/simple-demo/utils/respToDTO"
 	"github.com/RaymondCode/simple-demo/utils/verify"
 	"github.com/gin-gonic/gin"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"log"
 	"net/http"
 )
@@ -41,22 +38,13 @@ func FavoriteAction(c *gin.Context) {
 		return
 	}
 
-	// rpc client
-	conn, err := grpc.Dial("localhost:50053", grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		log.Fatalf("did not connect: %v", err)
-	}
-	defer conn.Close()
-	client := rpcFavorite.NewRPCFavoriteServiceClient(conn)
-
-	// call server
-	resp, err := client.FavoriteAction(context.Background(), &rpcFavorite.FavoriteRequest{UserId: userInfoVar.ID, Token: favoriteRequest.Token, VideoId: favoriteRequest.VideoID, ActionType: favoriteRequest.ActionType})
+	fs := service.FavoriteService{}
+	err := fs.FavoriteAction(userInfoVar.ID, &favoriteRequest)
 	if err != nil {
 		c.JSON(http.StatusOK, Response{StatusCode: 1, StatusMsg: "error in favorite action service: " + err.Error()})
 		return
 	}
-
-	c.JSON(http.StatusOK, Response{StatusCode: resp.StatusCode})
+	c.JSON(http.StatusOK, Response{StatusCode: 0})
 }
 
 // FavoriteList get from favorite table
@@ -79,21 +67,13 @@ func FavoriteList(c *gin.Context) {
 		return
 	}
 
-	// rpc client
-	conn, err := grpc.Dial("localhost:50053", grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		log.Fatalf("did not connect: %v", err)
-	}
-	defer conn.Close()
-	client := rpcFavorite.NewRPCFavoriteServiceClient(conn)
-
-	// call server
-	resp, err := client.FavoriteList(context.Background(), &rpcFavorite.FavoriteListRequest{UserId: favoriteListRequest.UserID, Token: favoriteListRequest.Token})
+	fs := service.FavoriteService{}
+	videos, err := fs.FavoriteList(&favoriteListRequest)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, Response{StatusCode: 1, StatusMsg: "error: favoriteList service" + err.Error()})
 		return
 	}
-	favoriteList := respToDTO.GetVideoListDTo(resp.VideoList)
+	favoriteList := respToDTO.GetVideoListDTO(*videos)
 
 	c.JSON(http.StatusOK, response.FavoriteListResponse{
 		Response: response.Response{

--- a/controller/feed.go
+++ b/controller/feed.go
@@ -1,17 +1,14 @@
 package controller
 
 import (
-	"context"
 	"github.com/RaymondCode/simple-demo/global"
+	"github.com/RaymondCode/simple-demo/model"
 	"github.com/RaymondCode/simple-demo/model/request"
 	"github.com/RaymondCode/simple-demo/model/response"
-	"github.com/RaymondCode/simple-demo/pb/rpcVideo"
+	"github.com/RaymondCode/simple-demo/service"
 	"github.com/RaymondCode/simple-demo/utils/respToDTO"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"log"
 	"net/http"
 	"time"
@@ -28,38 +25,19 @@ func Feed(c *gin.Context) {
 		return
 	}
 
-	// rpc client
-	conn, err := grpc.Dial("localhost:50052", grpc.WithInsecure())
-	if err != nil {
-		global.App.DY_LOG.Error("client conn error!", zap.Error(err))
-		log.Fatalf("did not connect: %v", err)
+	fs := service.FeedService{}
+	var videos *[]model.Video
+	if feedRequest.Token != "" {
+		videos, err = fs.FeedWithToken(&feedRequest)
+	} else {
+		videos, err = fs.FeedWithoutToken()
 	}
-	defer conn.Close()
-	client := rpcVideo.NewRPCVideoServiceClient(conn)
-	// set conn deadline
-	route(context.Background(), 2)
-
-	// call server
-	resp, err := client.Feed(context.Background(), &rpcVideo.FeedReq{
-		LatestTime: feedRequest.LatestTime,
-		Token:      feedRequest.Token,
-	})
 	if err != nil {
-		// 判断是否是超时错误
-		statusErr, ok := status.FromError(err)
-		if ok {
-			if statusErr.Code() == codes.DeadlineExceeded {
-				global.App.DY_LOG.Error("client.Search err: deadline", zap.Error(err))
-				log.Println("client.Search err: deadline ", zap.Error(err))
-			}
-		}
-		global.App.DY_LOG.Error("client.Search err: ", zap.Error(err))
-		log.Println("client.Search err: ", zap.Error(err))
-		global.App.DY_LOG.Error("feed server error!", zap.Error(err))
+		global.App.DY_LOG.Error("feed service error!", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, Response{StatusCode: 1, StatusMsg: err.Error()})
 		return
 	}
-	feedListReturn := respToDTO.GetVideoListDTo(resp.VideoList)
+	feedListReturn := respToDTO.GetVideoListDTO(*videos)
 	if feedListReturn == nil {
 		global.App.DY_LOG.Info("get feedList null")
 	}
@@ -69,11 +47,4 @@ func Feed(c *gin.Context) {
 		NextTime:  time.Now().Unix(),
 	})
 	return
-}
-
-func route(ctx context.Context, i time.Duration) {
-	clientDeadline := time.Now().Add(time.Duration(i * time.Second))
-	ctx, cancel := context.WithDeadline(ctx, clientDeadline)
-	defer cancel()
-
 }

--- a/controller/publish.go
+++ b/controller/publish.go
@@ -1,20 +1,16 @@
 package controller
 
 import (
-	"context"
 	"encoding/json"
 	"github.com/RaymondCode/simple-demo/global"
 	"github.com/RaymondCode/simple-demo/model"
 	"github.com/RaymondCode/simple-demo/model/request"
 	"github.com/RaymondCode/simple-demo/model/response"
-	"github.com/RaymondCode/simple-demo/pb/rpcVideo"
 	"github.com/RaymondCode/simple-demo/service"
 	"github.com/RaymondCode/simple-demo/utils/respToDTO"
 	"github.com/RaymondCode/simple-demo/utils/verify"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"log"
 	"net/http"
 	"path/filepath"
@@ -92,18 +88,13 @@ func PublishList(c *gin.Context) {
 		return
 	}
 
-	// rpc client
-	conn, err := grpc.Dial("localhost:50052", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	ps := service.PublishService{}
+	videos, err := ps.PublishList(&publishListRequest)
 	if err != nil {
-		log.Fatalf("did not connect: %v", err)
+		c.JSON(http.StatusInternalServerError, Response{StatusCode: 1, StatusMsg: err.Error()})
+		return
 	}
-	defer conn.Close()
-	client := rpcVideo.NewRPCVideoServiceClient(conn)
-
-	// call server
-	resp, err := client.GetPublishList(context.Background(), &rpcVideo.PublishListRequest{UserId: publishListRequest.UserID, Token: publishListRequest.Token})
-	publishVideoList := respToDTO.GetVideoListDTo(resp.VideoList)
-	// return
+	publishVideoList := respToDTO.GetVideoListDTO(videos)
 	c.JSON(http.StatusOK, response.PublishListResponse{
 		Response: response.Response{
 			StatusCode: 0,

--- a/controller/relation.go
+++ b/controller/relation.go
@@ -1,19 +1,16 @@
 package controller
 
 import (
-	"context"
 	"encoding/json"
 	"github.com/RaymondCode/simple-demo/global"
 	"github.com/RaymondCode/simple-demo/model"
 	"github.com/RaymondCode/simple-demo/model/request"
 	"github.com/RaymondCode/simple-demo/model/response"
-	"github.com/RaymondCode/simple-demo/pb/rpcFollow"
+	"github.com/RaymondCode/simple-demo/service"
 	"github.com/RaymondCode/simple-demo/utils/respToDTO"
 	"github.com/RaymondCode/simple-demo/utils/verify"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"log"
 	"net/http"
 	"strconv"
@@ -51,27 +48,14 @@ func RelationAction(c *gin.Context) {
 		return
 	}
 
-	// rpc client
-	conn, err := grpc.Dial("localhost:50055", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	rs := service.RelationService{}
+	err := rs.RelationAction(userInfoVar.ID, &relationActionRequest)
 	if err != nil {
-		log.Fatalf("did not connect: %v", err)
-	}
-	defer conn.Close()
-	client := rpcFollow.NewRPCFollowServiceClient(conn)
-
-	// call server
-	resp, err := client.FollowAction(context.Background(), &rpcFollow.FollowActionReq{
-		Token:      relationActionRequest.Token,
-		ToUserId:   relationActionRequest.ToUserID,
-		ActionType: relationActionRequest.ActionType,
-		UserId:     userInfoVar.ID,
-	})
-	if err != nil {
-		global.App.DY_LOG.Error("rpc error", zap.Error(err))
+		global.App.DY_LOG.Error("relation action error", zap.Error(err))
 		c.JSON(http.StatusBadRequest, Response{StatusCode: 1, StatusMsg: err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, Response{StatusCode: resp.StatusCode})
+	c.JSON(http.StatusOK, Response{StatusCode: 0})
 
 }
 
@@ -93,24 +77,13 @@ func FollowList(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, Response{StatusCode: 1, StatusMsg: "bind error"})
 		return
 	}
-	// rpc client
-	conn, err := grpc.Dial("localhost:50055", grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		log.Fatalf("did not connect: %v", err)
-	}
-	defer conn.Close()
-	client := rpcFollow.NewRPCFollowServiceClient(conn)
-
-	// call server
-	resp, err := client.GetFollowList(context.Background(), &rpcFollow.FollowListReq{
-		UserId: followListRequest.UserID,
-		Token:  followListRequest.Token,
-	})
+	rs := service.RelationService{}
+	users, err := rs.FollowList(&followListRequest)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, Response{StatusCode: 1, StatusMsg: err.Error()})
 		return
 	}
-	followList := respToDTO.GetUserListDTO(resp.UserList)
+	followList := respToDTO.GetUserListDTO(users)
 	c.JSON(http.StatusOK, response.FollowListResponse{
 		Response: response.Response{
 			StatusCode: 0,
@@ -135,24 +108,13 @@ func FollowerList(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, Response{StatusCode: 1, StatusMsg: "bind error"})
 		return
 	}
-	// rpc client
-	conn, err := grpc.Dial("localhost:50055", grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		log.Fatalf("did not connect: %v", err)
-	}
-	defer conn.Close()
-	client := rpcFollow.NewRPCFollowServiceClient(conn)
-
-	// call server
-	resp, err := client.GetFollowerList(context.Background(), &rpcFollow.FollowerListReq{
-		UserId: followerListRequest.UserID,
-		Token:  followerListRequest.Token,
-	})
+	rs := service.RelationService{}
+	users, err := rs.FollowerList(&followerListRequest)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, Response{StatusCode: 1, StatusMsg: err.Error()})
 		return
 	}
-	followerList := respToDTO.GetUserListDTO(resp.UserList)
+	followerList := respToDTO.GetUserListDTO(users)
 	c.JSON(http.StatusOK, response.FollowListResponse{
 		Response: response.Response{
 			StatusCode: 0,

--- a/controller/user.go
+++ b/controller/user.go
@@ -1,19 +1,16 @@
 package controller
 
 import (
-	"context"
 	"encoding/json"
 	"github.com/RaymondCode/simple-demo/global"
 	"github.com/RaymondCode/simple-demo/model"
 	"github.com/RaymondCode/simple-demo/model/request"
 	"github.com/RaymondCode/simple-demo/model/response"
-	"github.com/RaymondCode/simple-demo/pb/rpcUser"
+	"github.com/RaymondCode/simple-demo/service"
 	"github.com/RaymondCode/simple-demo/utils"
 	"github.com/RaymondCode/simple-demo/utils/verify"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"log"
 	"net/http"
 	"strconv"
@@ -28,31 +25,22 @@ func Register(c *gin.Context) {
 		return
 	}
 
-	// rpc init
-	conn, err := grpc.Dial("localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	// call service directly
+	us := service.UserService{}
+	err, newUser := us.Register(&model.User{Name: r.Username, Username: r.Username, Password: r.Password, FollowCount: 0, FollowerCount: 0})
 	if err != nil {
-		log.Fatalf("did not connect: %v", err)
-	}
-	defer conn.Close()
-	client := rpcUser.NewRPCUserServiceClient(conn)
-
-	// call server
-	resp, err := client.Register(context.Background(), &rpcUser.RegisterRequest{Username: r.Username, Password: r.Password})
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, response.RegisterResponse{Response: response.Response{StatusCode: -1, StatusMsg: "failed: rpc error " + err.Error()}})
+		c.JSON(http.StatusInternalServerError, response.RegisterResponse{Response: response.Response{StatusCode: -1, StatusMsg: err.Error()}})
 		return
 	}
 
-	// return
-	token, _ := utils.GenToken(resp.UserId)
+	token, _ := utils.GenToken(newUser.ID)
 	c.JSON(http.StatusOK, response.RegisterResponse{
 		Response: response.Response{
 			StatusCode: 0,
-			StatusMsg:  "success: create register rpcUser",
+			StatusMsg:  "success: register user",
 		},
-		UserId: resp.UserId,
-		// TODO register token
-		Token: token,
+		UserId: newUser.ID,
+		Token:  token,
 	})
 }
 
@@ -72,29 +60,20 @@ func Login(c *gin.Context) {
 		return
 	}
 
-	// rpc client
-	conn, err := grpc.Dial("localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	us := service.UserService{}
+	returnUser, token, err := us.Login(&model.User{Name: l.Username, Username: l.Username, Password: l.Password})
 	if err != nil {
-		log.Fatalf("did not connect: %v", err)
-	}
-	defer conn.Close()
-	client := rpcUser.NewRPCUserServiceClient(conn)
-
-	// call server
-	resp, err := client.Login(context.Background(), &rpcUser.LoginRequest{Username: l.Username, Password: l.Password})
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"rpc server error": err.Error()})
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	// return
 	c.JSON(http.StatusOK, response.LoginResponse{
 		Response: response.Response{
 			StatusCode: 0,
 			StatusMsg:  "success: login in",
 		},
-		UserId: resp.UserId,
-		Token:  resp.Token,
+		UserId: returnUser.ID,
+		Token:  token,
 	})
 
 }
@@ -118,21 +97,15 @@ func UserInfo(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, response.UserInfoResponse{Response: response.Response{StatusCode: 1, StatusMsg: "error: userID error"}})
 	}
 
-	// rpc client
-	conn, err := grpc.Dial("localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	us := service.UserService{}
+	returnUser, err := us.GetUserInfo(userIdNum, userInfoVar.ID)
 	if err != nil {
-		log.Fatalf("did not connect: %v", err)
+		c.JSON(http.StatusInternalServerError, response.UserInfoResponse{Response: response.Response{StatusCode: 1, StatusMsg: err.Error()}})
+		return
 	}
-	defer conn.Close()
-	client := rpcUser.NewRPCUserServiceClient(conn)
 
-	// call server
-	resp, err := client.GetUserInfo(context.Background(), &rpcUser.UserInfoRequest{UserId: userIdNum})
-	returnUser := resp.User
-
-	// DTO
 	userinfo := response.UserInfo{
-		ID:            returnUser.Id,
+		ID:            returnUser.ID,
 		Name:          returnUser.Name,
 		FollowCount:   returnUser.FollowCount,
 		FollowerCount: returnUser.FollowerCount,

--- a/utils/respToDTO/user.go
+++ b/utils/respToDTO/user.go
@@ -1,25 +1,25 @@
 package respToDTO
 
 import (
+	"github.com/RaymondCode/simple-demo/model"
 	"github.com/RaymondCode/simple-demo/model/dto"
-	"github.com/RaymondCode/simple-demo/pb/rpcUser"
 )
 
-func GetUserDTo(user *rpcUser.User) (userInfo *dto.UserDTO) {
-	userInfo = &dto.UserDTO{
-		ID:            user.Id,
+func GetUserDTO(user *model.User) *dto.UserDTO {
+	return &dto.UserDTO{
+		ID:            user.ID,
 		Name:          user.Name,
 		FollowCount:   user.FollowCount,
 		FollowerCount: user.FollowerCount,
 		IsFollow:      user.IsFollow,
 	}
-	return userInfo
 }
 
-func GetUserListDTO(users []*rpcUser.User) *[]dto.UserDTO {
+func GetUserListDTO(users []model.User) *[]dto.UserDTO {
 	userList := make([]dto.UserDTO, len(users))
 	for i := 0; i < len(users); i++ {
-		userList[i] = *GetUserDTo(users[i])
+		user := users[i]
+		userList[i] = *GetUserDTO(&user)
 	}
 	return &userList
 }

--- a/utils/respToDTO/video.go
+++ b/utils/respToDTO/video.go
@@ -1,28 +1,29 @@
 package respToDTO
 
 import (
+	"github.com/RaymondCode/simple-demo/model"
 	"github.com/RaymondCode/simple-demo/model/dto"
-	"github.com/RaymondCode/simple-demo/pb/rpcVideo"
 )
 
-func GetVideoDTo(video *rpcVideo.Video) *dto.VideoDTO {
-	var videoInfo dto.VideoDTO
-	videoInfo.ID = video.Id
-	videoInfo.UserID = video.User.Id
-	videoInfo.User = *GetUserDTo(video.User)
-	videoInfo.PlayUrl = video.PlayUrl
-	videoInfo.CoverUrl = video.CoverUrl
-	videoInfo.FavoriteCount = video.FavoriteCount
-	videoInfo.CommentCount = video.CommentCount
-	videoInfo.IsFavorite = video.IsFavorite
-	videoInfo.Title = video.Title
-	return &videoInfo
+func GetVideoDTO(video *model.Video) *dto.VideoDTO {
+	return &dto.VideoDTO{
+		ID:            video.ID,
+		UserID:        video.User.ID,
+		User:          *GetUserDTO(&video.User),
+		PlayUrl:       video.PlayUrl,
+		CoverUrl:      video.CoverUrl,
+		FavoriteCount: video.FavoriteCount,
+		CommentCount:  video.CommentCount,
+		IsFavorite:    video.IsFavorite,
+		Title:         video.Title,
+	}
 }
 
-func GetVideoListDTo(videos []*rpcVideo.Video) *[]dto.VideoDTO {
+func GetVideoListDTO(videos []model.Video) *[]dto.VideoDTO {
 	videoInfo := make([]dto.VideoDTO, len(videos))
 	for i := 0; i < len(videos); i++ {
-		videoInfo[i] = *GetVideoDTo(videos[i])
+		video := videos[i]
+		videoInfo[i] = *GetVideoDTO(&video)
 	}
 	return &videoInfo
 }


### PR DESCRIPTION
## Summary
- remove grpc client calls from controllers
- convert response DTO helpers to work with models
- call service functions directly

## Testing
- `go test ./...` *(fails: no route to host)*